### PR TITLE
Security: expose a way to set nonce on style elements to conform to CSP policies

### DIFF
--- a/packages/css/src/style-element.ts
+++ b/packages/css/src/style-element.ts
@@ -1,31 +1,32 @@
 // This allows user to optionally specify a nonce value to be set on all <style> elements,
 // in order to conform to a CSP policy and avoid some CSS injection vulnerabilities.
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src#unsafe_inline_styles
-let nonce: string;
-export function setNonce(value: string) {
-  nonce = value;
+
+export interface StyleElementOptions {
+  id?: string | false;
+  nonce?: string;
 }
 
 export function appendStyle(
   css: string | string[],
-  id?: string | false
+  options: StyleElementOptions = {},
 ): {
   element: HTMLStyleElement;
   id: string | false | undefined;
 } {
   if (Array.isArray(css)) css = css.join("\n");
   const head = document.head || document.getElementsByTagName("head")[0];
-  const prevElement = id && document.getElementById(id);
+  const prevElement = options.id && document.getElementById(options.id);
   if (prevElement && prevElement instanceof HTMLStyleElement) {
     setStyleElementText(prevElement, css);
     subscribeStyle(prevElement);
-    return { element: prevElement, id };
+    return { element: prevElement, id: options.id };
   } else {
     if (prevElement) prevElement.remove();
-    const element = createStyleElement(css, id);
+    const element = createStyleElement(css, options);
     subscribeStyle(element);
     head.appendChild(element);
-    return { element, id };
+    return { element, id: options.id };
   }
 }
 
@@ -58,10 +59,10 @@ export function setStyleElementText(element: HTMLStyleElement, text: string) {
   }
 }
 
-export function createStyleElement(css: string, id?: string | false) {
+export function createStyleElement(css: string, options: StyleElementOptions) {
   const element = document.createElement("style");
-  if (id) element.setAttribute("id", id);
-  if (nonce) element.setAttribute("nonce", nonce);
+  if (options.id) element.setAttribute("id", options.id);
+  if (options.nonce) element.setAttribute("nonce", options.nonce);
   element.type = "text/css";
   setStyleElementText(element, css);
   return element;

--- a/packages/css/src/style-element.ts
+++ b/packages/css/src/style-element.ts
@@ -1,3 +1,11 @@
+// This allows user to optionally specify a nonce value to be set on all <style> elements,
+// in order to conform to a CSP policy and avoid some CSS injection vulnerabilities.
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src#unsafe_inline_styles
+let nonce: string;
+export function setNonce(value: string) {
+  nonce = value;
+}
+
 export function appendStyle(
   css: string | string[],
   id?: string | false
@@ -53,6 +61,7 @@ export function setStyleElementText(element: HTMLStyleElement, text: string) {
 export function createStyleElement(css: string, id?: string | false) {
   const element = document.createElement("style");
   if (id) element.setAttribute("id", id);
+  if (nonce) element.setAttribute("nonce", nonce);
   element.type = "text/css";
   setStyleElementText(element, css);
   return element;

--- a/packages/site/src/layouts/MainLayout/Nav.tsx
+++ b/packages/site/src/layouts/MainLayout/Nav.tsx
@@ -93,7 +93,7 @@ export const navConfig: Config[] = [
     type: "section",
     text: "Getting started",
     icon: RocketLaunchIcon,
-    items: ["Installation", "Usage"].map((text) => ({
+    items: ["Installation", "Usage", "Security"].map((text) => ({
       type: "link",
       href: `/getting-started/${toFolder(text)}`,
       text,

--- a/packages/site/src/pages/gettingStarted/SecurityPage.tsx
+++ b/packages/site/src/pages/gettingStarted/SecurityPage.tsx
@@ -1,0 +1,37 @@
+import Link from "@suid/material/Link";
+import Typography from "@suid/material/Typography";
+import PageNav from "~/components/PageNav";
+import PaperCode from "~/components/PaperCode";
+import example from "./SecurityPage/Example?raw";
+
+export default function SecurityPage() {
+  return (
+    <>
+      <Typography component="h1" variant="h4" sx={{ mt: 1 }}>
+        Security
+      </Typography>
+      <Typography variant="body1" sx={{ mt: 2 }}>
+        SUID creates {"<style>"} tags dynamically for each component. This can be an issue if you have a strict{" "}
+        <Link href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy" target="_blank">
+          Content Security Policy
+        </Link>
+        set. In such case you need to instruct SUID to apply a{" "}
+        <Link href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src#unsafe_inline_styles" target="_blank">
+          nonce
+        </Link>
+        attribute to its {"<style>"} tags.
+      </Typography>
+      <Typography component="h2" variant="h5" sx={{ mt: 2, mb: 1 }}>
+        Setting a nonce
+      </Typography>
+      <PaperCode
+        language="tsx"
+        value={example
+          .split(/\r?\n/)
+          .filter((v) => !v.trim().startsWith("// eslint-disable"))
+          .join("\n")}
+      />
+      <PageNav sx={{ mt: 2 }} />
+    </>
+  );
+}

--- a/packages/site/src/pages/gettingStarted/SecurityPage/Example.tsx
+++ b/packages/site/src/pages/gettingStarted/SecurityPage/Example.tsx
@@ -1,0 +1,11 @@
+// @refresh
+import { setNonce } from "@suid/css/style-element";
+import { render } from "solid-js/web";
+
+setNonce(/* Nonce value */);
+
+function App() {
+  // ...
+}
+
+render(() => <App />, document.getElementById("root")!);

--- a/packages/system/src/StyledEngineContext/StyledEngineContext.tsx
+++ b/packages/system/src/StyledEngineContext/StyledEngineContext.tsx
@@ -1,0 +1,9 @@
+import { createContext } from "solid-js";
+
+export interface StyledEngineContextValue {
+  nonce?: string;
+}
+
+const StyledEngineContext = createContext<StyledEngineContextValue>({});
+
+export default StyledEngineContext;

--- a/packages/system/src/StyledEngineContext/index.ts
+++ b/packages/system/src/StyledEngineContext/index.ts
@@ -1,0 +1,1 @@
+export { default, StyledEngineContextValue } from "./StyledEngineContext";

--- a/packages/system/src/StyledEngineProvider/StyledEngineProvider.tsx
+++ b/packages/system/src/StyledEngineProvider/StyledEngineProvider.tsx
@@ -1,0 +1,16 @@
+import StyledEngineContext, { StyledEngineContextValue } from "../StyledEngineContext";
+import { splitProps, JSXElement } from "solid-js";
+
+function StyledEngineProvider(props: StyledEngineContextValue&{
+  children: JSXElement;
+}) {
+  const [localProps, contextValue] = splitProps(props, ['children']);
+  return (
+    <StyledEngineContext.Provider
+      value={contextValue}
+      children={localProps.children}
+    />
+  );
+}
+
+export default StyledEngineProvider;

--- a/packages/system/src/StyledEngineProvider/index.tsx
+++ b/packages/system/src/StyledEngineProvider/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "./StyledEngineProvider";

--- a/packages/system/src/createSxClass.ts
+++ b/packages/system/src/createSxClass.ts
@@ -1,5 +1,6 @@
 import mergeSxObjects from "./mergeSxObjects";
 import SxProps from "./sxProps";
+import StyledEngineContext from "./StyledEngineContext";
 import createStyle from "@suid/css/createStyle";
 import {
   appendStyle,
@@ -7,7 +8,7 @@ import {
   subscribeStyle,
   unsubscribeStyle,
 } from "@suid/css/style-element";
-import { createRenderEffect, createSignal, onCleanup } from "solid-js";
+import { createRenderEffect, createSignal, onCleanup, useContext } from "solid-js";
 
 function createSxClass(value: () => SxProps | undefined) {
   const [name, setName] = createSignal("");
@@ -41,7 +42,8 @@ function createSxClass(value: () => SxProps | undefined) {
       if (styleElement) {
         subscribeStyle(styleElement);
       } else {
-        styleElement = appendStyle(result.rules, result.cacheId).element;
+        const { nonce } = useContext(StyledEngineContext);
+        styleElement = appendStyle(result.rules, { id: result.cacheId, nonce }).element;
       }
     }
 

--- a/packages/system/src/index.tsx
+++ b/packages/system/src/index.tsx
@@ -1,6 +1,7 @@
 export * from "./colorManipulator";
 export * from "./styleFunctionSx";
 export * from "./breakpoints";
+export { default as StyleEngineProvider } from "./StyledEngineProvider";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export type SystemProps<Theme> = {};
 export type { SxProps } from "./sxProps";


### PR DESCRIPTION
I came across [this issue](https://github.com/tauri-apps/tauri/issues/3427#issuecomment-1131471010) while trying to use SUID inside Tauri, which sets a strict CSP policy by default - and that prevents SUID styles from loading.

A way to solve that problem is to specify a nonce attribute on `<style>` tags:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src#unsafe_inline_styles

I also tried updating the docs, but I didn't have much time, so I could've messed something up.