### PR TITLE
Component - Converted Material UI Table Footer.

### DIFF
--- a/packages/material/src/TableFooter/TableFooter.tsx
+++ b/packages/material/src/TableFooter/TableFooter.tsx
@@ -1,0 +1,67 @@
+import { TableFooterTypeMap } from ".";
+import Tablelvl2Context, {
+  Tablelvl2ContextProps,
+} from "../Table/Tablelvl2Context";
+import styled from "../styles/styled";
+import { getTableFooterUtilityClass } from "./tableFooterClasses";
+import createComponentFactory from "@suid/base/createComponentFactory";
+import clsx from "clsx";
+
+const $ = createComponentFactory<TableFooterTypeMap>()({
+  name: "MuiTableFooter",
+  propDefaults: ({ set }) =>
+    set({
+      component: "div",
+    }),
+  selfPropNames: ["children", "classes"],
+  utilityClass: getTableFooterUtilityClass,
+  slotClasses: () => ({
+    root: ["root"],
+  }),
+});
+
+const TableFooterRoot = styled("tfoot", {
+  name: "MuiTableFooter",
+  slot: "Root",
+  overridesResolver: (props, styles) => styles.root,
+})({
+  display: "table-footer-group",
+});
+
+const tablelvl2: Tablelvl2ContextProps = {
+  variant: "footer",
+};
+
+const defaultComponent = "tfoot";
+
+/**
+ *
+ * Demos:
+ *
+ * - [Tables](https://mui.com/components/tables/)
+ *
+ * API:
+ *
+ * - [TableFooter API](https://mui.com/material-ui/api/table-footer/)
+ */
+const TableFooter = $.component(function TableFooter({
+  classes,
+  allProps,
+  props,
+  otherProps,
+}) {
+  return (
+    <Tablelvl2Context.Provider value={tablelvl2}>
+      <TableFooterRoot
+        {...otherProps}
+        className={clsx(classes.root, otherProps.className)}
+        ownerState={allProps}
+        role={allProps.component === defaultComponent ? null : "rowgroup"}
+      >
+        {props.children}
+      </TableFooterRoot>
+    </Tablelvl2Context.Provider>
+  );
+});
+
+export default TableFooter;

--- a/packages/material/src/TableFooter/TableFooterProps.tsx
+++ b/packages/material/src/TableFooter/TableFooterProps.tsx
@@ -1,0 +1,35 @@
+import { Theme } from "..";
+import { OverrideProps } from "../OverridableComponent";
+import { TableFooterClasses } from "./tableFooterClasses";
+import { SxProps } from "@suid/system";
+import * as ST from "@suid/types";
+import * as JSX from "solid-js";
+
+export type TableFooterTypeMap<P = {}, D extends ST.ElementType = "div"> = {
+  name: "MuiTableFooter";
+  selfProps: {
+    /**
+     * The content of the component, normally `Table`.
+     */
+    children?: JSX.JSXElement;
+
+    /**
+     * Override or extend the styles applied to the component.
+     */
+    classes?: Partial<TableFooterClasses>;
+
+    /**
+     * The system prop that allows defining system overrides as well as additional CSS styles.
+     */
+    sx?: SxProps<Theme>;
+  };
+  props: P & TableFooterTypeMap["selfProps"];
+  defaultComponent: D;
+};
+
+export type TableFooterProps<
+  D extends ST.ElementType = TableFooterTypeMap["defaultComponent"],
+  P = {}
+> = OverrideProps<TableFooterTypeMap<P, D>, D>;
+
+export default TableFooterProps;

--- a/packages/material/src/TableFooter/index.tsx
+++ b/packages/material/src/TableFooter/index.tsx
@@ -1,0 +1,7 @@
+export { default } from "./TableFooter";
+export * from "./TableFooter";
+
+export { default as tableFooterClasses } from "./tableFooterClasses";
+export * from "./tableFooterClasses";
+
+export * from "./TableFooterProps";

--- a/packages/material/src/TableFooter/tableFooterClasses.ts
+++ b/packages/material/src/TableFooter/tableFooterClasses.ts
@@ -1,0 +1,19 @@
+import { generateUtilityClass, generateUtilityClasses } from "@suid/base";
+
+export interface TableFooterClasses {
+  /** Styles applied to the root element. */
+  root: string;
+}
+
+export type TableFooterClassKey = keyof TableFooterClasses;
+
+export function getTableFooterUtilityClass(slot: string): string {
+  return generateUtilityClass("MuiTableFooter", slot);
+}
+
+const tableFooterClasses: TableFooterClasses = generateUtilityClasses(
+  "MuiTableFooter",
+  ["root"]
+);
+
+export default tableFooterClasses;


### PR DESCRIPTION
Added in the TableFooter component from https://github.com/mui/material-ui/tree/master/packages/mui-material/src/TableFooter into the codebase.

Also, regarding the implementation of tests, as the MUI version does not contain a test file for the TableFooter component, is the expected feature for this project to also not include any extra testing not present in MUI? 