### PR TITLE
fix: insert style nodes before existing style nodes to allow override

### DIFF
--- a/.changeset/poor-frogs-share.md
+++ b/.changeset/poor-frogs-share.md
@@ -1,0 +1,5 @@
+---
+"@suid/css": minor
+---
+
+leave user style nodes as the last ones to allow override of SUID components style

--- a/packages/css/src/dom/appendStyleElement.ts
+++ b/packages/css/src/dom/appendStyleElement.ts
@@ -1,6 +1,6 @@
-import createStyleElement from "./createStyleElement";
-import registerStyleElementUsage from "./registerStyleElementUsage";
-import setStyleElementText from "./setStyleElementText";
+import createStyleElement from './createStyleElement'
+import registerStyleElementUsage from './registerStyleElementUsage'
+import setStyleElementText from './setStyleElementText'
 
 function appendStyleElement(
   css: string | string[],
@@ -18,7 +18,8 @@ function appendStyleElement(
     if (prevElement) prevElement.remove();
     const element = createStyleElement(css, attributes);
     registerStyleElementUsage(element);
-    head.appendChild(element);
+    const firstStyleElement = head.querySelector('style')
+    head.insertBefore(element, firstStyleElement)
     return element;
   }
 }


### PR DESCRIPTION
this fix leaves the user style nodes as the last ones in the header in order to give them more specificity and allow them to override the style of SUID components.

Do you see any downside?