### PR TITLE
Changes to support 1.7

### DIFF
--- a/packages/material/src/Alert/Alert.tsx
+++ b/packages/material/src/Alert/Alert.tsx
@@ -179,8 +179,8 @@ const Alert = $.component(function Alert({
       <Show when={props.icon !== false}>
         <AlertIcon ownerState={allProps} class={classes.icon}>
           {props.icon ||
-            props.iconMapping?.[props.severity] ||
-            defaultIconMapping[props.severity]}
+            props.iconMapping?.[props.severity]?.() ||
+            defaultIconMapping[props.severity]?.()}
         </AlertIcon>
       </Show>
       <AlertMessage ownerState={allProps} class={classes.message}>

--- a/packages/material/src/Avatar/Avatar.tsx
+++ b/packages/material/src/Avatar/Avatar.tsx
@@ -245,7 +245,7 @@ const Avatar = $.defineComponent(function Avatar(inProps) {
       class={clsx(classes.root, props.class)}
       {...other}
     >
-      {children}
+      {children()}
     </AvatarRoot>
   );
 });

--- a/packages/material/src/ButtonBase/TouchRipple.tsx
+++ b/packages/material/src/ButtonBase/TouchRipple.tsx
@@ -8,7 +8,7 @@ import clsx from "clsx";
 import {
   createEffect,
   createSignal,
-  mapArray,
+  For,
   mergeProps,
   onCleanup,
 } from "solid-js";
@@ -334,42 +334,44 @@ const TouchRipple = $.component(function TouchRipple({ props, otherProps }) {
       ref={container}
       {...otherProps}
     >
-      {mapArray(ripples, (data) => (
-        <TouchRippleRipple
-          in={inProps[data.id]}
-          onExited={() => {
-            setRipples((oldRipples) =>
-              oldRipples.filter((v) => v.id !== data.id)
-            );
-            delete inProps[data.id];
-          }}
-          classes={{
-            ripple: clsx(props.classes.ripple, touchRippleClasses.ripple),
-            rippleVisible: clsx(
-              props.classes.rippleVisible,
-              touchRippleClasses.rippleVisible
-            ),
-            ripplePulsate: clsx(
-              props.classes.ripplePulsate,
-              touchRippleClasses.ripplePulsate
-            ),
-            child: clsx(props.classes.child, touchRippleClasses.child),
-            childLeaving: clsx(
-              props.classes.childLeaving,
-              touchRippleClasses.childLeaving
-            ),
-            childPulsate: clsx(
-              props.classes.childPulsate,
-              touchRippleClasses.childPulsate
-            ),
-          }}
-          timeout={DURATION}
-          pulsate={data.params.pulsate}
-          rippleX={data.params.rippleX}
-          rippleY={data.params.rippleY}
-          rippleSize={data.params.rippleSize}
-        />
-      ))}
+      <For each={ripples()}>
+        {(data) => (
+          <TouchRippleRipple
+            in={inProps[data.id]}
+            onExited={() => {
+              setRipples((oldRipples) =>
+                oldRipples.filter((v) => v.id !== data.id)
+              );
+              delete inProps[data.id];
+            }}
+            classes={{
+              ripple: clsx(props.classes.ripple, touchRippleClasses.ripple),
+              rippleVisible: clsx(
+                props.classes.rippleVisible,
+                touchRippleClasses.rippleVisible
+              ),
+              ripplePulsate: clsx(
+                props.classes.ripplePulsate,
+                touchRippleClasses.ripplePulsate
+              ),
+              child: clsx(props.classes.child, touchRippleClasses.child),
+              childLeaving: clsx(
+                props.classes.childLeaving,
+                touchRippleClasses.childLeaving
+              ),
+              childPulsate: clsx(
+                props.classes.childPulsate,
+                touchRippleClasses.childPulsate
+              ),
+            }}
+            timeout={DURATION}
+            pulsate={data.params.pulsate}
+            rippleX={data.params.rippleX}
+            rippleY={data.params.rippleY}
+            rippleSize={data.params.rippleSize}
+          />
+        )}
+      </For>
     </TouchRippleRoot>
   );
 });

--- a/packages/material/src/Checkbox/CheckboxProps.tsx
+++ b/packages/material/src/Checkbox/CheckboxProps.tsx
@@ -28,7 +28,7 @@ export interface CheckboxTypeMap<P = {}, D extends ElementType = "div"> {
      * The icon to display when the component is checked.
      * @default <CheckBoxIcon />
      */
-    checkedIcon?: JSXElement;
+    checkedIcon?: JSXElement | (() => JSXElement);
     /**
      * Override or extend the styles applied to the component.
      */
@@ -59,7 +59,7 @@ export interface CheckboxTypeMap<P = {}, D extends ElementType = "div"> {
      * The icon to display when the component is unchecked.
      * @default <CheckBoxOutlineBlankIcon />
      */
-    icon?: JSXElement;
+    icon?: JSXElement | (() => JSXElement);
     /**
      * The id of the `input` element.
      */
@@ -76,7 +76,7 @@ export interface CheckboxTypeMap<P = {}, D extends ElementType = "div"> {
      * The icon to display when the component is indeterminate.
      * @default <IndeterminateCheckBoxIcon />
      */
-    indeterminateIcon?: JSXElement;
+    indeterminateIcon?: JSXElement | (() => JSXElement);
     /**
      * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes) applied to the `input` element.
      */

--- a/packages/material/src/Chip/Chip.tsx
+++ b/packages/material/src/Chip/Chip.tsx
@@ -479,7 +479,7 @@ const Chip = $.component(function Chip({
       <ChipLabel class={clsx(classes.label)} ownerState={allProps}>
         {props.label}
       </ChipLabel>
-      {deleteIcon}
+      {deleteIcon()}
     </$ChipRoot>
   );
 });

--- a/packages/material/src/Drawer/Drawer.tsx
+++ b/packages/material/src/Drawer/Drawer.tsx
@@ -205,7 +205,7 @@ const Drawer = $.component(function Drawer({
         class={clsx(classes.paper, props.PaperProps.class)}
         ownerState={allProps as any}
       >
-        {resolved}
+        {resolved()}
       </DrawerPaper>
     );
   }

--- a/packages/material/src/InputBase/InputBaseProps.tsx
+++ b/packages/material/src/InputBase/InputBaseProps.tsx
@@ -11,7 +11,7 @@ import {
   ChangeEventHandler,
   KeyboardEventHandler,
 } from "@suid/types";
-import { JSX, JSXElement } from "solid-js";
+import { Component, JSX, JSXElement } from "solid-js";
 
 export interface InputBasePropsSizeOverrides {}
 
@@ -111,7 +111,7 @@ export interface InputBaseTypeMap<P = {}, D extends ElementType = "div"> {
      * Either a string to use a HTML element or a component.
      * @default 'input'
      */
-    inputComponent?: JSXElement;
+    inputComponent?: string | Component<any>;
     /**
      * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes) applied to the `input` element.
      * @default {}

--- a/packages/material/src/MenuList/MenuList.tsx
+++ b/packages/material/src/MenuList/MenuList.tsx
@@ -344,7 +344,7 @@ const MenuList = $.defineComponent(function MenuList(props) {
       tabIndex={baseProps.autoFocus ? 0 : -1}
       {...other}
     >
-      {items}
+      {items()}
     </List>
   );
 });

--- a/packages/material/src/NativeSelect/NativeSelect.tsx
+++ b/packages/material/src/NativeSelect/NativeSelect.tsx
@@ -99,7 +99,7 @@ const NativeSelect = $.defineComponent(function NativeSelect(inProps) {
 
   return (
     <Input
-      inputComponent={NativeSelectInput as JSXElement}
+      inputComponent={NativeSelectInput}
       inputProps={inputProps as InputProps["inputProps"]}
       {...(other as InputProps)}
       class={clsx(

--- a/packages/material/src/Radio/RadioProps.tsx
+++ b/packages/material/src/Radio/RadioProps.tsx
@@ -4,7 +4,7 @@ import { RadioClasses } from "./radioClasses";
 import { SxProps } from "@suid/system";
 import { OverridableStringUnion, OverrideProps } from "@suid/types";
 import * as ST from "@suid/types";
-import * as JSX from "solid-js";
+import { JSXElement } from "solid-js";
 
 export interface RadioPropsSizeOverrides {}
 
@@ -17,7 +17,7 @@ export type RadioTypeMap<P = {}, D extends ST.ElementType = "div"> = {
      * The icon to display when the component is checked.
      * @default <RadioButtonIcon checked />
      */
-    checkedIcon?: JSX.JSXElement;
+    checkedIcon?: JSXElement | (() => JSXElement);
 
     /**
      * Override or extend the styles applied to the component.
@@ -48,7 +48,7 @@ export type RadioTypeMap<P = {}, D extends ST.ElementType = "div"> = {
      * The icon to display when the component is unchecked.
      * @default <RadioButtonIcon />
      */
-    icon?: JSX.JSXElement;
+    icon?: JSXElement | (() => JSXElement);
 
     /**
      * The size of the component.

--- a/packages/material/src/internal/SwitchBase.tsx
+++ b/packages/material/src/internal/SwitchBase.tsx
@@ -10,7 +10,7 @@ import createComponentFactory from "@suid/base/createComponentFactory";
 import createRef from "@suid/system/createRef";
 import { InPropsOf } from "@suid/types";
 import clsx from "clsx";
-import { createEffect, mergeProps } from "solid-js";
+import { createEffect, mergeProps, JSXElement } from "solid-js";
 
 type OwnerState = InPropsOf<SwitchBaseTypeMap> & {
   size?: string;
@@ -206,7 +206,7 @@ const SwitchBase = $.component(function SwitchBase({
         value={inputValue()}
         {...(props.inputProps || {})}
       />
-      {checked() ? props.checkedIcon : props.icon}
+      {(checked() ? props.checkedIcon : props.icon) as JSXElement}
       {otherProps.children}
     </SwitchBaseRoot>
   );

--- a/packages/material/src/internal/SwitchBaseProps.ts
+++ b/packages/material/src/internal/SwitchBaseProps.ts
@@ -14,7 +14,7 @@ export interface SwitchBaseTypeMap<P = {}, D extends ElementType = "div"> {
      * If `true`, the component is checked.
      */
     checked?: boolean;
-    checkedIcon: JSXElement;
+    checkedIcon: JSXElement | (() => JSXElement);
     /**
      * Override or extend the styles applied to the component.
      */
@@ -41,7 +41,7 @@ export interface SwitchBaseTypeMap<P = {}, D extends ElementType = "div"> {
      * @default false
      */
     edge?: "start" | "end" | false;
-    icon: JSXElement;
+    icon: JSXElement | (() => JSXElement);
     /**
      * The id of the `input` element.
      */

--- a/packages/material/src/utils/createSvgIcon.tsx
+++ b/packages/material/src/utils/createSvgIcon.tsx
@@ -1,10 +1,13 @@
 import SvgIcon, { SvgIconProps } from "../SvgIcon";
 import { JSXElement } from "solid-js";
 
-export default function createSvgIcon(path: JSXElement, displayName: string) {
-  const Component = (props: SvgIconProps) => (
+export default function createSvgIcon(
+  path: () => JSXElement,
+  displayName: string
+) {
+  const Component = (props: SvgIconProps): JSXElement => (
     <SvgIcon data-testid={`${displayName}Icon`} {...props}>
-      {path}
+      {path()}
     </SvgIcon>
   );
 

--- a/packages/site/src/components/ComponentInfo.tsx
+++ b/packages/site/src/components/ComponentInfo.tsx
@@ -7,7 +7,7 @@ import {
   Component,
   createMemo,
   JSXElement,
-  mapArray,
+  For,
   Match,
   Show,
   Switch,
@@ -87,12 +87,12 @@ export default function ComponentInfo(props: {
         <Typography component="h2" variant="h5" sx={{ my: 2 }}>
           {props.examples?.length === 1 ? "Example" : "Examples"}
         </Typography>
-        {mapArray(
-          () =>
-            props.examples?.map((v) =>
-              typeof v === "function" ? { component: v } : v
-            ),
-          (example) => (
+        <For
+          each={props.examples?.map((v) =>
+            typeof v === "function" ? { component: v } : v
+          )}
+        >
+          {(example) => (
             <Box sx={{ mb: 2 }}>
               <Switch>
                 <Match when={typeof example.title === "string"}>
@@ -134,8 +134,8 @@ export default function ComponentInfo(props: {
                 }}
               />
             </Box>
-          )
-        )}
+          )}
+        </For>
       </Show>
 
       <Show when={moreExamples()}>

--- a/packages/site/src/layouts/MainLayout/Nav.tsx
+++ b/packages/site/src/layouts/MainLayout/Nav.tsx
@@ -16,7 +16,7 @@ import {
 } from "@suid/material";
 import snakeCase from "@suid/utils/snakeCase";
 import uncapitalize from "@suid/utils/uncapitalize";
-import { Component, JSXElement, mapArray } from "solid-js";
+import { Component, JSXElement, For } from "solid-js";
 import { Pages, tryPreload } from "~/Routing";
 import { useLayoutContext } from "./LayoutContext";
 
@@ -372,9 +372,8 @@ function NavLink(props: { text: string; href: string }) {
 export function Nav() {
   return (
     <List dense>
-      {mapArray(
-        () => navConfig,
-        (item) => {
+      <For each={navConfig}>
+        {(item) => {
           if (item.type === "section") {
             return (
               <>
@@ -382,16 +381,14 @@ export function Nav() {
                   icon={item.icon ? <item.icon /> : undefined}
                   text={item.text}
                 >
-                  {mapArray(
-                    () => item.items,
-                    (item) => {
+                  <For each={item.items}>
+                    {(item) => {
                       if (item.type === "section") {
                         return (
                           <>
                             <NavSubSection text={item.text} />
-                            {mapArray(
-                              () => item.items,
-                              (item) => {
+                            <For each={item.items}>
+                              {(item) => {
                                 if (item.type === "link")
                                   return (
                                     <NavLink
@@ -399,15 +396,15 @@ export function Nav() {
                                       href={item.href}
                                     />
                                   );
-                              }
-                            )}
+                              }}
+                            </For>
                           </>
                         );
                       } else if (item.type === "link") {
                         return <NavLink text={item.text} href={item.href} />;
                       }
-                    }
-                  )}
+                    }}
+                  </For>
                 </NavSection>
                 <Divider sx={{ my: 1 }} />
               </>
@@ -415,8 +412,8 @@ export function Nav() {
           } else if (item.type === "link") {
             return <NavLink text={item.text} href={item.href} />;
           }
-        }
-      )}
+        }}
+      </For>
     </List>
   );
 }

--- a/packages/site/src/pages/components/DrawerPage/TemporaryDrawerExample.tsx
+++ b/packages/site/src/pages/components/DrawerPage/TemporaryDrawerExample.tsx
@@ -12,7 +12,6 @@ import {
   ListItemText,
 } from "@suid/material";
 import { DrawerProps } from "@suid/material/Drawer";
-import { mapArray } from "solid-js";
 import { createMutable } from "solid-js/store";
 
 type Anchor = NonNullable<DrawerProps["anchor"]>;
@@ -45,57 +44,48 @@ export default function TemporaryDrawer() {
       onKeyDown={toggleDrawer(anchor, false)}
     >
       <List>
-        {mapArray(
-          () => ["Inbox", "Starred", "Send email", "Drafts"],
-          (text, index) => (
-            <ListItem disablePadding>
-              <ListItemButton>
-                <ListItemIcon>
-                  {index() % 2 === 0 ? <InboxIcon /> : <MailIcon />}
-                </ListItemIcon>
-                <ListItemText primary={text} />
-              </ListItemButton>
-            </ListItem>
-          )
-        )}
+        {["Inbox", "Starred", "Send email", "Drafts"].map((text, index) => (
+          <ListItem disablePadding>
+            <ListItemButton>
+              <ListItemIcon>
+                {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
+              </ListItemIcon>
+              <ListItemText primary={text} />
+            </ListItemButton>
+          </ListItem>
+        ))}
       </List>
       <Divider />
       <List>
-        {mapArray(
-          () => ["All mail", "Trash", "Spam"],
-          (text, index) => (
-            <ListItem disablePadding>
-              <ListItemButton>
-                <ListItemIcon>
-                  {index() % 2 === 0 ? <InboxIcon /> : <MailIcon />}
-                </ListItemIcon>
-                <ListItemText primary={text} />
-              </ListItemButton>
-            </ListItem>
-          )
-        )}
+        {["All mail", "Trash", "Spam"].map((text, index) => (
+          <ListItem disablePadding>
+            <ListItemButton>
+              <ListItemIcon>
+                {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
+              </ListItemIcon>
+              <ListItemText primary={text} />
+            </ListItemButton>
+          </ListItem>
+        ))}
       </List>
     </Box>
   );
 
   return (
     <div>
-      {mapArray(
-        () => ["left", "right", "top", "bottom"] as Anchor[],
-        (anchor) => (
-          <>
-            <Button onClick={toggleDrawer(anchor, true)}>{anchor}</Button>
-            <Drawer
-              anchor={anchor}
-              open={state[anchor]}
-              sx={{ zIndex: 9999 }}
-              onClose={toggleDrawer(anchor, false)}
-            >
-              {list(anchor)}
-            </Drawer>
-          </>
-        )
-      )}
+      {(["left", "right", "top", "bottom"] as Anchor[]).map((anchor) => (
+        <>
+          <Button onClick={toggleDrawer(anchor, true)}>{anchor}</Button>
+          <Drawer
+            anchor={anchor}
+            open={state[anchor]}
+            sx={{ zIndex: 9999 }}
+            onClose={toggleDrawer(anchor, false)}
+          >
+            {list(anchor)}
+          </Drawer>
+        </>
+      ))}
     </div>
   );
 }

--- a/packages/system/src/Dynamic/Dynamic.tsx
+++ b/packages/system/src/Dynamic/Dynamic.tsx
@@ -48,7 +48,7 @@ function ServerDynamic<T>(
 }
 
 // https://github.com/solidjs/solid/blob/12c0dbbbf9f9fdf798c6682e57aee8ea763cf1ba/packages/solid/web/src/index.ts#L114
-export function Dynamic(props: any): Accessor<JSX.Element> {
+export function Dynamic(props: any): JSX.Element {
   if (isServer) return ServerDynamic(props);
   const [p, others] = splitProps(props, ["$component"]);
   const cached = createMemo<Function | string>(() => p.$component);
@@ -70,7 +70,7 @@ export function Dynamic(props: any): Accessor<JSX.Element> {
       default:
         break;
     }
-  });
+  }) as unknown as JSX.Element;
 }
 
 export default Dynamic;


### PR DESCRIPTION
@juanrgm I took your comments seriously from the Solid 1.7 PR. I thought I'd take a quick look to see what I could do to resolve the type issues. Most things were trivial. The hardest part which I mostly left intact was that there are a bunch of APIs that take functions or not, basically treating JSX.Elements, Accessors, and Components as interchangeable. This is precisely what I'm trying to get stricter about in 1.7. Since I didn't want to impact API and I could tell equality checks were being used in places on functions (so changing to Getters was no good) I basically left stuff as is and just expanded the types.

I also changed inline mapArrays to `<For>` mostly a stylistic thing but it might actually be slightly more performant this way as we don't wrap Components whereas `mapArray` expressions would be. 

Honestly you don't have to merge this if you have better idea of how to address the changes in 1.7 but I just wanted to take a look at how it would be for a component library in our ecosystem to do the migration. And I'm pretty happy overall. This enforces better patterns and makes what is going on much clearer. 