### PR TITLE
Implement `BottomNavigation`/`BottomNavigationAction`

### DIFF
--- a/.changeset/serious-eagles-juggle.md
+++ b/.changeset/serious-eagles-juggle.md
@@ -1,0 +1,6 @@
+---
+"@suid/material": minor
+"@suid/site": minor
+---
+
+Implement `BottomNavigation`/`BottomNavigationAction`

--- a/packages/material/src/BottomNavigation/BottomNavigation.tsx
+++ b/packages/material/src/BottomNavigation/BottomNavigation.tsx
@@ -1,0 +1,103 @@
+import { BottomNavigationTypeMap } from ".";
+import styled from "../styles/styled";
+import BottomNavigationContext from "./BottomNavigationContext";
+import { getBottomNavigationUtilityClass } from "./bottomNavigationClasses";
+import createComponentFactory from "@suid/base/createComponentFactory";
+import createRef from "@suid/system/createRef";
+import clsx from "clsx";
+import {
+  splitProps,
+  mergeProps,
+  createMemo,
+  children,
+  ChildrenReturn,
+} from "solid-js";
+
+const $ = createComponentFactory<BottomNavigationTypeMap>()({
+  name: "MuiBottomNavigation",
+  selfPropNames: ["children", "classes", "onChange", "showLabels", "value"],
+  utilityClass: getBottomNavigationUtilityClass,
+  slotClasses: () => ({
+    root: ["root"],
+  }),
+});
+
+const BottomNavigationRoot = styled("div", {
+  name: "MuiBottomNavigation",
+  slot: "Root",
+  overridesResolver: (props, styles) => styles.root,
+})(({ theme }) => ({
+  display: "flex",
+  justifyContent: "center",
+  height: 56,
+  backgroundColor: theme.palette.background.paper,
+}));
+
+/**
+ *
+ * Demos:
+ *
+ * - [Bottom Navigation](https://mui.com/components/bottom-navigation/)
+ *
+ * API:
+ *
+ * - [BottomNavigation API](https://mui.com/api/bottom-navigation/)
+ */
+const BottomNavigation = $.defineComponent(function BottomNavigation(inProps) {
+  const ref = createRef(inProps);
+  const props = $.useThemeProps({ props: inProps });
+  const [, other] = splitProps(props, [
+    "children",
+    "class",
+    "component",
+    "onChange",
+    "showLabels",
+    "value",
+  ]);
+
+  const baseProps = mergeProps(
+    {
+      component: "div",
+      showLabels: false,
+    },
+    props
+  );
+
+  const ownerState = mergeProps(props, {
+    get component() {
+      return baseProps.component;
+    },
+    get showLabels() {
+      return baseProps.showLabels;
+    },
+  });
+
+  const classes = $.useClasses(ownerState);
+
+  let resolvedChildren: ChildrenReturn;
+
+  return (
+    <BottomNavigationRoot
+      as={baseProps.component}
+      class={clsx(classes.root, props.class)}
+      ref={ref}
+      ownerState={ownerState}
+      {...other}
+    >
+      <BottomNavigationContext.Provider
+        value={{
+          showLabels: createMemo(() => props.showLabels),
+          selectedValue: createMemo(() => props.value),
+          onChange: createMemo(() => props.onChange),
+          getIndex: (child) => {
+            return resolvedChildren.toArray().indexOf(child);
+          },
+        }}
+      >
+        {(resolvedChildren = children(() => props.children))()}
+      </BottomNavigationContext.Provider>
+    </BottomNavigationRoot>
+  );
+});
+
+export default BottomNavigation;

--- a/packages/material/src/BottomNavigation/BottomNavigationContext.ts
+++ b/packages/material/src/BottomNavigation/BottomNavigationContext.ts
@@ -1,0 +1,19 @@
+import { ChangeEventHandler } from "@suid/types";
+import { Accessor, createContext } from "solid-js";
+import { ResolvedJSXElement } from "solid-js/types/reactive/signal";
+
+export interface IBottomNavigationContext {
+  onChange: Accessor<ChangeEventHandler<HTMLDivElement, any> | undefined>;
+  showLabels: Accessor<boolean>;
+  selectedValue: Accessor<any>;
+  getIndex: (element: ResolvedJSXElement) => number;
+}
+
+const BottomNavigationContext = createContext<IBottomNavigationContext>({
+  onChange: () => () => undefined,
+  showLabels: () => false,
+  selectedValue: () => undefined,
+  getIndex: () => 0,
+});
+
+export default BottomNavigationContext;

--- a/packages/material/src/BottomNavigation/BottomNavigationProps.tsx
+++ b/packages/material/src/BottomNavigation/BottomNavigationProps.tsx
@@ -1,0 +1,58 @@
+import { Theme } from "..";
+import { BottomNavigationClasses } from "./bottomNavigationClasses";
+import { SxProps } from "@suid/system";
+import * as ST from "@suid/types";
+import { JSXElement } from "solid-js";
+
+export type BottomNavigationTypeMap<
+  P = {},
+  D extends ST.ElementType = "div"
+> = {
+  name: "MuiBottomNavigation";
+  defaultPropNames: "showLabels";
+  selfProps: {
+    /**
+     * The content of the component.
+     */
+    children?: JSXElement;
+
+    /**
+     * Override or extend the styles applied to the component.
+     */
+    classes?: Partial<BottomNavigationClasses>;
+
+    /**
+     * Callback fired when the value changes.
+     *
+     * @param {SyntheticEvent} event The event source of the callback. **Warning**: This is a generic event not a change event.
+     * @param {any} value We default to the index of the child.
+     */
+    onChange?: ST.ChangeEventHandler<HTMLDivElement, any>;
+
+    /**
+     * If `true`, all `BottomNavigationAction`s will show their labels.
+     * By default, only the selected `BottomNavigationAction` will show its label.
+     * @default false
+     */
+    showLabels?: boolean;
+
+    /**
+     * The system prop that allows defining system overrides as well as additional CSS styles.
+     */
+    sx?: SxProps<Theme>;
+
+    /**
+     * The value of the currently selected `BottomNavigationAction`.
+     */
+    value?: any;
+  };
+  props: P & BottomNavigationTypeMap["selfProps"];
+  defaultComponent: D;
+};
+
+export type BottomNavigationProps<
+  D extends ST.ElementType = BottomNavigationTypeMap["defaultComponent"],
+  P = {}
+> = ST.OverrideProps<BottomNavigationTypeMap<P, D>, D>;
+
+export default BottomNavigationProps;

--- a/packages/material/src/BottomNavigation/bottomNavigationClasses.ts
+++ b/packages/material/src/BottomNavigation/bottomNavigationClasses.ts
@@ -1,0 +1,20 @@
+import generateUtilityClass from "@suid/base/generateUtilityClass";
+import generateUtilityClasses from "@suid/base/generateUtilityClasses";
+
+export interface BottomNavigationClasses {
+  /** Styles applied to the root element. */
+  root: string;
+}
+
+export type BottomNavigationClassKey = keyof BottomNavigationClasses;
+
+export function getBottomNavigationUtilityClass(slot: string): string {
+  return generateUtilityClass("MuiBottomNavigation", slot);
+}
+
+const bottomNavigationClasses: BottomNavigationClasses = generateUtilityClasses(
+  "MuiBottomNavigation",
+  ["root"]
+);
+
+export default bottomNavigationClasses;

--- a/packages/material/src/BottomNavigation/index.tsx
+++ b/packages/material/src/BottomNavigation/index.tsx
@@ -1,0 +1,7 @@
+export { default } from "./BottomNavigation";
+export * from "./BottomNavigation";
+
+export { default as bottomNavigationClasses } from "./bottomNavigationClasses";
+export * from "./bottomNavigationClasses";
+
+export * from "./BottomNavigationProps";

--- a/packages/material/src/BottomNavigationAction/BottomNavigationAction.tsx
+++ b/packages/material/src/BottomNavigationAction/BottomNavigationAction.tsx
@@ -1,0 +1,179 @@
+import { BottomNavigationActionTypeMap } from ".";
+import BottomNavigationContext from "../BottomNavigation/BottomNavigationContext";
+import ButtonBase from "../ButtonBase";
+import styled from "../styles/styled";
+import bottomNavigationActionClasses, {
+  getBottomNavigationActionUtilityClass,
+} from "./bottomNavigationActionClasses";
+import createComponentFactory from "@suid/base/createComponentFactory";
+import createRef from "@suid/system/createRef";
+import clsx from "clsx";
+import {
+  createSignal,
+  mergeProps,
+  onMount,
+  splitProps,
+  useContext,
+  createMemo,
+} from "solid-js";
+import { ResolvedJSXElement } from "solid-js/types/reactive/signal";
+
+interface ExtraProps {
+  selected?: boolean;
+  showLabel?: boolean;
+}
+
+const $ = createComponentFactory<
+  BottomNavigationActionTypeMap & { props: ExtraProps }
+>()({
+  name: "MuiBottomNavigationAction",
+  selfPropNames: ["children", "classes", "icon", "label", "showLabel", "value"],
+  utilityClass: getBottomNavigationActionUtilityClass,
+  slotClasses: (ownerState) => ({
+    root: [
+      "root",
+      !ownerState.showLabel && !ownerState.selected && "iconOnly",
+      ownerState.selected && "selected",
+    ],
+    label: [
+      "label",
+      !ownerState.showLabel && !ownerState.selected && "iconOnly",
+      ownerState.selected && "selected",
+    ],
+  }),
+});
+
+const BottomNavigationActionRoot = styled(ButtonBase, {
+  name: "MuiBottomNavigationAction",
+  slot: "Root",
+  overridesResolver: (props, styles) => {
+    const { ownerState } = props;
+
+    return [
+      styles.root,
+      !ownerState.showLabel && !ownerState.selected && styles.iconOnly,
+    ];
+  },
+})<ExtraProps>(({ theme, ownerState }) => ({
+  transition: theme.transitions.create(["color", "padding-top"], {
+    duration: theme.transitions.duration.short,
+  }),
+  padding: "6px 12px 8px",
+  minWidth: 80,
+  maxWidth: 168,
+  color: theme.palette.text.secondary,
+  flexDirection: "column",
+  flex: "1",
+  ...(!ownerState.showLabel &&
+    !ownerState.selected && {
+      paddingTop: 16,
+    }),
+  [`&.${bottomNavigationActionClasses.selected}`]: {
+    paddingTop: 6,
+    color: theme.palette.primary.main,
+  },
+}));
+
+const BottomNavigationActionLabel = styled("span", {
+  name: "MuiBottomNavigationAction",
+  slot: "Label",
+  overridesResolver: (props, styles) => styles.label,
+})<ExtraProps>(({ theme, ownerState }) => ({
+  fontFamily: theme.typography.fontFamily,
+  fontSize: theme.typography.pxToRem(12),
+  opacity: 1,
+  transition: "font-size 0.2s, opacity 0.2s",
+  transitionDelay: "0.1s",
+  ...(!ownerState.showLabel &&
+    !ownerState.selected && {
+      opacity: 0,
+      transitionDelay: "0s",
+    }),
+  [`&.${bottomNavigationActionClasses.selected}`]: {
+    fontSize: theme.typography.pxToRem(14),
+  },
+}));
+
+/**
+ *
+ * Demos:
+ *
+ * - [Bottom Navigation](https://mui.com/components/bottom-navigation/)
+ *
+ * API:
+ *
+ * - [BottomNavigationAction API](https://mui.com/api/bottom-navigation-action/)
+ * - inherits [ButtonBase API](https://mui.com/api/button-base/)
+ */
+const BottomNavigationAction = $.defineComponent(
+  function BottomNavigationAction(inProps) {
+    const ref = createRef<HTMLElement>(inProps);
+    const props = $.useThemeProps({ props: inProps });
+    const [, other] = splitProps(props, [
+      "class",
+      "icon",
+      "label",
+      "onClick",
+      "showLabel",
+      "value",
+    ]);
+
+    const navCtx = useContext(BottomNavigationContext);
+
+    const [self, setSelf] = createSignal<ResolvedJSXElement>();
+    onMount(() => setSelf(ref.current));
+
+    const value = createMemo(() => {
+      if (props.value !== undefined) {
+        return props.value;
+      }
+      if (self() !== undefined) {
+        return navCtx.getIndex(self());
+      }
+      return undefined;
+    });
+
+    const handleChange = (event: any) => {
+      const onChange = navCtx.onChange();
+      if (typeof onChange === "function") {
+        onChange(event, value());
+      }
+
+      if (typeof props.onClick === "function") {
+        props.onClick(event);
+      }
+    };
+
+    const ownerState = mergeProps(props, {
+      get selected() {
+        return navCtx.selectedValue() === value();
+      },
+      get showLabel() {
+        return props.showLabel ?? navCtx.showLabels();
+      },
+    });
+
+    const classes = $.useClasses(ownerState);
+
+    return (
+      <BottomNavigationActionRoot
+        ref={ref}
+        class={clsx(classes.root, props.class)}
+        focusRipple
+        onClick={handleChange}
+        ownerState={ownerState}
+        {...other}
+      >
+        {props.icon}
+        <BottomNavigationActionLabel
+          class={classes.label}
+          ownerState={ownerState}
+        >
+          {props.label}
+        </BottomNavigationActionLabel>
+      </BottomNavigationActionRoot>
+    );
+  }
+);
+
+export default BottomNavigationAction;

--- a/packages/material/src/BottomNavigationAction/BottomNavigationActionProps.tsx
+++ b/packages/material/src/BottomNavigationAction/BottomNavigationActionProps.tsx
@@ -1,0 +1,64 @@
+import { Theme } from "..";
+import { ExtendButtonBaseTypeMap } from "../ButtonBase";
+import { BottomNavigationActionClasses } from "./bottomNavigationActionClasses";
+import { SxProps } from "@suid/system";
+import * as ST from "@suid/types";
+import { JSXElement } from "solid-js";
+
+export type BottomNavigationActionTypeMap<
+  P = {},
+  D extends ST.ElementType = "div"
+> = {
+  name: "MuiBottomNavigationAction";
+  selfProps: {
+    /**
+     * This prop isn't supported.
+     * Use the `component` prop if you need to change the children structure.
+     */
+    children?: JSXElement;
+
+    /**
+     * Override or extend the styles applied to the component.
+     */
+    classes?: Partial<BottomNavigationActionClasses>;
+
+    /**
+     * The icon to display.
+     */
+    icon?: JSXElement;
+
+    /**
+     * The label element.
+     */
+    label?: JSXElement;
+
+    /**
+     * If `true`, the `BottomNavigationAction` will show its label.
+     * By default, only the selected `BottomNavigationAction`
+     * inside `BottomNavigation` will show its label.
+     *
+     * The prop defaults to the value (`false`) inherited from the parent BottomNavigation component.
+     */
+    showLabel?: boolean;
+
+    /**
+     * The system prop that allows defining system overrides as well as additional CSS styles.
+     */
+    sx?: SxProps<Theme>;
+
+    /**
+     * You can provide your own value. Otherwise, we fallback to the child position index.
+     */
+    value?: any;
+  };
+} & ExtendButtonBaseTypeMap<{
+  props: P & BottomNavigationActionTypeMap["selfProps"];
+  defaultComponent: D;
+}>;
+
+export type BottomNavigationActionProps<
+  D extends ST.ElementType = BottomNavigationActionTypeMap["defaultComponent"],
+  P = {}
+> = ST.OverrideProps<BottomNavigationActionTypeMap<P, D>, D>;
+
+export default BottomNavigationActionProps;

--- a/packages/material/src/BottomNavigationAction/bottomNavigationActionClasses.ts
+++ b/packages/material/src/BottomNavigationAction/bottomNavigationActionClasses.ts
@@ -1,0 +1,30 @@
+import generateUtilityClass from "@suid/base/generateUtilityClass";
+import generateUtilityClasses from "@suid/base/generateUtilityClasses";
+
+export interface BottomNavigationActionClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** State class applied to the root element if selected. */
+  selected: string;
+  /** State class applied to the root element if `showLabel={false}` and not selected. */
+  iconOnly: string;
+  /** Styles applied to the label's span element. */
+  label: string;
+}
+
+export type BottomNavigationActionClassKey =
+  keyof BottomNavigationActionClasses;
+
+export function getBottomNavigationActionUtilityClass(slot: string): string {
+  return generateUtilityClass("MuiBottomNavigationAction", slot);
+}
+
+const bottomNavigationActionClasses: BottomNavigationActionClasses =
+  generateUtilityClasses("MuiBottomNavigationAction", [
+    "root",
+    "iconOnly",
+    "selected",
+    "label",
+  ]);
+
+export default bottomNavigationActionClasses;

--- a/packages/material/src/BottomNavigationAction/index.tsx
+++ b/packages/material/src/BottomNavigationAction/index.tsx
@@ -1,0 +1,7 @@
+export { default } from "./BottomNavigationAction";
+export * from "./BottomNavigationAction";
+
+export { default as bottomNavigationActionClasses } from "./bottomNavigationActionClasses";
+export * from "./bottomNavigationActionClasses";
+
+export * from "./BottomNavigationActionProps";

--- a/packages/material/src/index.tsx
+++ b/packages/material/src/index.tsx
@@ -12,6 +12,8 @@ export { default as Avatar } from "./Avatar";
 export { default as Backdrop } from "./Backdrop";
 export { default as Badge } from "./Badge";
 export { default as Box } from "./Box";
+export { default as BottomNavigation } from "./BottomNavigation";
+export { default as BottomNavigationAction } from "./BottomNavigationAction";
 export { default as Breadcrumbs } from "./Breadcrumbs";
 export { default as Button } from "./Button";
 export { default as ButtonBase } from "./ButtonBase";

--- a/packages/site/src/pages/components/BottomNavigationPage/BasicBottomNavigationExample.tsx
+++ b/packages/site/src/pages/components/BottomNavigationPage/BasicBottomNavigationExample.tsx
@@ -1,0 +1,23 @@
+import { Favorite, LocationOn, Restore } from "@suid/icons-material";
+import { BottomNavigation, BottomNavigationAction, Box } from "@suid/material";
+import { createSignal } from "solid-js";
+
+export default function BasicBottomNavigationExample() {
+  const [value, setValue] = createSignal(0);
+
+  return (
+    <Box sx={{ width: 500 }}>
+      <BottomNavigation
+        showLabels
+        value={value()}
+        onChange={(event, newValue) => {
+          setValue(newValue);
+        }}
+      >
+        <BottomNavigationAction label="Recents" icon={<Restore />} />
+        <BottomNavigationAction label="Favorites" icon={<Favorite />} />
+        <BottomNavigationAction label="Nearby" icon={<LocationOn />} />
+      </BottomNavigation>
+    </Box>
+  );
+}

--- a/packages/site/src/pages/components/BottomNavigationPage/BottomNavigationPage.tsx
+++ b/packages/site/src/pages/components/BottomNavigationPage/BottomNavigationPage.tsx
@@ -1,0 +1,23 @@
+import { BottomNavigation } from "@suid/material";
+import ComponentInfo from "~/components/ComponentInfo";
+import BasicBottomNavigationExample from "./BasicBottomNavigationExample";
+import UnlabeledBottomNavigationExample from "./UnlabeledBottomNavigationExample";
+
+export default function BottomNavigationPage() {
+  return (
+    <ComponentInfo
+      name={BottomNavigation.name}
+      moreExamples={false}
+      examples={[
+        {
+          component: BasicBottomNavigationExample,
+          title: "Basic Navigation",
+        },
+        {
+          component: UnlabeledBottomNavigationExample,
+          title: "Unlabeled",
+        },
+      ]}
+    />
+  );
+}

--- a/packages/site/src/pages/components/BottomNavigationPage/UnlabeledBottomNavigationExample.tsx
+++ b/packages/site/src/pages/components/BottomNavigationPage/UnlabeledBottomNavigationExample.tsx
@@ -1,0 +1,32 @@
+import { Favorite, Folder, LocationOn, Restore } from "@suid/icons-material";
+import { BottomNavigation, BottomNavigationAction } from "@suid/material";
+import { createSignal } from "solid-js";
+
+export default function UnlabeledBottomNavigationExample() {
+  const [value, setValue] = createSignal("recents");
+
+  return (
+    <BottomNavigation
+      sx={{ width: 500 }}
+      value={value()}
+      onChange={(_, newValue) => setValue(newValue)}
+    >
+      <BottomNavigationAction
+        label="Recents"
+        value="recents"
+        icon={<Restore />}
+      />
+      <BottomNavigationAction
+        label="Favorites"
+        value="favorites"
+        icon={<Favorite />}
+      />
+      <BottomNavigationAction
+        label="Nearby"
+        value="nearby"
+        icon={<LocationOn />}
+      />
+      <BottomNavigationAction label="Folder" value="folder" icon={<Folder />} />
+    </BottomNavigation>
+  );
+}


### PR DESCRIPTION
Does what the title says. A couple examples are included in the docs.

Implementation notes:
* The original MUI code manipulated children in a way which is impossible in Solid, so I re-implemented that part to use context. I'm somewhat new to Solid so it's possible that wasn't the most idiomatic solution, but it seemed similar to what `ButtonGroup` and `FormControl` do.