### PR TITLE
Refactor code for `init`, `pkgFile`, `functions`, and `npm` modules

### DIFF
--- a/packages/create-suid/src/utils/npm.ts
+++ b/packages/create-suid/src/utils/npm.ts
@@ -1,4 +1,4 @@
-import { request } from "https";
+import { get } from "https";
 
 export async function fetchLatestManifest(name: string) {
   const url = `https://registry.npmjs.org/${name}/latest`;
@@ -8,13 +8,11 @@ export async function fetchLatestManifest(name: string) {
     dependencies?: Record<string, string>;
     devDependencies?: Record<string, string>;
   }>((resolve, reject) => {
-    let json = "";
-    const req = request(url, (res) => {
+    get(url, (res) => {
+      let json = "";
       res.on("data", (chunk) => (json += chunk));
-      res.on("close", () => resolve(JSON.parse(json)));
-    });
-    req.on("error", reject);
-    req.end();
+      res.on("end", () => resolve(JSON.parse(json)));
+    }).on("error", reject);
   });
 }
 


### PR DESCRIPTION
This pull request contains several refactoring changes to improve the code quality and readability of the `init`, `pkgFile`, `functions`, and `npm` modules. The main changes are:

- Simplify the code by using absolute paths, optional chaining, destructuring assignment, and `inquirer.prompt` with an array of questions, in the `init` module.
- Optimize the package file generation code by using default values, `map` calls, and nullish coalescing operator in the `pkgFile` module.
- Optimize the `isEmptyDir` and `createFiles` functions by using `every`, `Promise.all`, and `pathJoin` in the functions module.
- Use `get` method from `https` module instead of `request` to simplify the code in the `npm` module.

Please review the changes and let me know if you have any feedback or suggestions.