### PR TITLE
fix(material): make appear working

### DIFF
--- a/.changeset/forty-forks-shave.md
+++ b/.changeset/forty-forks-shave.md
@@ -1,0 +1,6 @@
+---
+"@suid/material": patch
+"@suid/base": patch
+---
+
+fix(material): make appear working

--- a/packages/base/src/Transition/Transition.tsx
+++ b/packages/base/src/Transition/Transition.tsx
@@ -139,13 +139,25 @@ export function Transition(inProps: TransitionProps) {
 
   createEffect((firstTime) => {
     if (props.in) {
-      untrack(() => props.onEnter?.());
-      setStatus("entering");
+      untrack(() => {
+        if (status() !== "entering" && status() !== "entered") {
+          props.onEnter?.();
+          setStatus("entering");
+        }
+      });
     } else {
-      if (!firstTime) {
-        untrack(() => props.onExit?.());
-        setStatus("exiting");
-      }
+      untrack(() => {
+        if (!firstTime) {
+          if (
+            status() !== "exiting" &&
+            status() !== "exited" &&
+            status() !== "unmounted"
+          ) {
+            props.onExit?.();
+            setStatus("exiting");
+          }
+        }
+      });
     }
     return false;
   }, true);

--- a/packages/material/src/Drawer/Drawer.tsx
+++ b/packages/material/src/Drawer/Drawer.tsx
@@ -10,7 +10,14 @@ import { getDrawerUtilityClass } from "./drawerClasses";
 import createComponentFactory from "@suid/base/createComponentFactory";
 import createElementRef from "@suid/system/createElementRef";
 import clsx from "clsx";
-import { children, createSignal, Match, onMount, Switch } from "solid-js";
+import {
+  children,
+  createMemo,
+  createSignal,
+  Match,
+  onMount,
+  Switch,
+} from "solid-js";
 
 const $ = createComponentFactory<DrawerTypeMap>()({
   name: "MuiDrawer",
@@ -190,11 +197,9 @@ const Drawer = $.component(function Drawer({
   // We use this state is order to skip the appear transition during the
   // initial mount of the component.
 
-  const [mounted, setMounted] = createSignal(false);
   const element = createElementRef(otherProps);
   const theme = useTheme();
   const resolved = children(() => props.children);
-  onMount(() => setMounted(true));
 
   function InternalDrawer() {
     return (
@@ -211,6 +216,8 @@ const Drawer = $.component(function Drawer({
   }
 
   function SlidingDrawer() {
+    const [mounted, setMounted] = createSignal(false);
+    onMount(() => setMounted(true));
     const anchorInvariant = getAnchor(theme, props.anchor) as Anchor;
 
     return (
@@ -225,6 +232,12 @@ const Drawer = $.component(function Drawer({
       </Slide>
     );
   }
+  const slidingDrawerVisible = createMemo(
+    () => props.variant === "persistent" || props.variant === "temporary"
+  );
+  const resolvedSlidingDrawer = children(
+    () => slidingDrawerVisible() && <SlidingDrawer />
+  );
 
   return (
     <Switch>
@@ -245,7 +258,7 @@ const Drawer = $.component(function Drawer({
           ownerState={allProps}
           ref={element}
         >
-          <SlidingDrawer />
+          {resolvedSlidingDrawer()}
         </DrawerDockedRoot>
       </Match>
       {
@@ -266,7 +279,7 @@ const Drawer = $.component(function Drawer({
             {...(props.ModalProps ?? {})}
             transition
           >
-            <SlidingDrawer />
+            {resolvedSlidingDrawer()}
           </DrawerRoot>
         </Match>
       }


### PR DESCRIPTION
Fixed the bug that when the `appear` attribute of `Fade` and `Slide` was `false`, the animation would still be played when the component was mounted for the first time

I also fixed a bug where `Drawer` would play animations when it was first mounted.

~~In MUI, the `slidingDrawer` is loaded and then added to the `RootSlot`, but not in Solidjs, where you need to wait for the child component to call children before the component can be mounted.(Or I don't know any other way.) So I give `setMounted(true)`; `requestAnimationFrame` has been added so that it is 'mounted' after the child component is mounted.~~