### PR TITLE
fix(site): fix main width between 900 and 1074

### DIFF
--- a/.changeset/puny-suits-tan.md
+++ b/.changeset/puny-suits-tan.md
@@ -1,0 +1,5 @@
+---
+"@suid/site": patch
+---
+
+fix(site):fix main width between 900 and 1074

--- a/packages/site/src/layouts/MainLayout/MainLayout.tsx
+++ b/packages/site/src/layouts/MainLayout/MainLayout.tsx
@@ -126,7 +126,7 @@ export default function MainLayout(props: { children?: JSXElement }) {
               </Box>
             </Drawer>
           </Show>
-          <Box component="main" sx={{ width: 1 }}>
+          <Box component="main" sx={{ width: 1, minWidth: 0 }}>
             <Toolbar />
             <Show when={playgroundLoaded()}>
               <RoutingElementContainer


### PR DESCRIPTION
Fixed a bug where content overflowed the viewport when the viewport width of the website was between 900 and 1074

| Before | After |
|-|-|
| <img width="685" alt="Snipaste_2025-06-17_11-29-18" src="https://github.com/user-attachments/assets/cab37a4a-61f1-451d-a5e8-de9cb3fdf9bd" /> | <img width="690" alt="Snipaste_2025-06-17_11-29-33" src="https://github.com/user-attachments/assets/47587e6a-4eb4-4cf1-a613-5f7ec8ef2176" /> |
