### PR TITLE
fix(codemod): rename -if option to --if

### DIFF
--- a/.changeset/violet-papayas-watch.md
+++ b/.changeset/violet-papayas-watch.md
@@ -1,0 +1,5 @@
+---
+"@suid/codemod": patch
+---
+
+fix(codemod): rename -if option to --if

--- a/packages/codemod/src/bin.ts
+++ b/packages/codemod/src/bin.ts
@@ -90,7 +90,7 @@ program
     ["packages/*/{src,test}/**/*.{ts,tsx}"] as string[]
   )
   .option(
-    "-if, --import-filters [patterns]",
+    "--if, --import-filters [patterns]",
     "Filters by import patterns",
     (value, previous) => {
       if (fixEsmFlags.firstTime.importFilters) {


### PR DESCRIPTION
When using codemod, the following error occurs and it cannot be used:

```
PS F:\my\programming\website\others\solid\suid> pnpm codemod mui2suid -h -if Tooltip

> suid@1.0.0 codemod F:\my\programming\website\others\solid\suid
> tsx packages/codemod/src/bin.ts "mui2suid" "-h" "-if" "Tooltip"

F:\my\programming\website\others\solid\suid\node_modules\.pnpm\commander@14.0.0\node_modules\commander\lib\option.js:354
      throw new Error(
            ^

Error: option creation failed due to '-if' in option flags '-if, --import-filters [patterns]'
- a short flag is a single dash and a single character
  - either use a single dash and a single character (for a short flag)
  - or use a double dash for a long option (and can have two, like '--ws, --workspace')
    at splitOptionFlags (F:\my\programming\website\others\solid\suid\node_modules\.pnpm\commander@14.0.0\node_modules\commander\lib\option.js:354:13)
    at new Option (F:\my\programming\website\others\solid\suid\node_modules\.pnpm\commander@14.0.0\node_modules\commander\lib\option.js:20:25)
    at Command.createOption (F:\my\programming\website\others\solid\suid\node_modules\.pnpm\commander@14.0.0\node_modules\commander\lib\command.js:587:12)
    at Command._optionEx (F:\my\programming\website\others\solid\suid\node_modules\.pnpm\commander@14.0.0\node_modules\commander\lib\command.js:748:25)
    at Command.option (F:\my\programming\website\others\solid\suid\node_modules\.pnpm\commander@14.0.0\node_modules\commander\lib\command.js:790:17)
    at <anonymous> (F:\my\programming\website\others\solid\suid\packages\codemod\src\bin.ts:92:4)
    at ModuleJob.run (node:internal/modules/esm/module_job:271:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:578:26)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:116:5)

Node.js v22.14.0
 ELIFECYCLE  Command failed with exit code 1.
```