### PR TITLE
fix(codemod): use 'ref' identifier as first

### DIFF
--- a/.changeset/tender-dots-search.md
+++ b/.changeset/tender-dots-search.md
@@ -1,0 +1,5 @@
+---
+"@suid/codemod": patch
+---
+
+fix(codemod): use 'ref' identifier as first

--- a/packages/codemod/src/transforms/replaceMuiUseForkRef.ts
+++ b/packages/codemod/src/transforms/replaceMuiUseForkRef.ts
@@ -11,7 +11,10 @@ export default function replaceMuiUseForkRef(node: Identifier) {
   const expr = node.getFirstAncestorByKindOrThrow(ts.SyntaxKind.CallExpression);
 
   const varStm = expr.getFirstAncestorByKind(ts.SyntaxKind.VariableStatement);
-  const [a, b] = expr.getArguments();
+  let [a, b] = expr.getArguments();
+  if (b.getText() === "ref") {
+    [a, b] = [b, a];
+  }
   const aName = a.getText();
 
   if (Node.isIdentifier(b)) {

--- a/packages/codemod/test/transforms/replaceMuiUseForkRef.test.ts
+++ b/packages/codemod/test/transforms/replaceMuiUseForkRef.test.ts
@@ -27,4 +27,22 @@ describe("replaceMuiUseForkRef", () => {
       `console.log(ref, ref, ref)`
     );
   });
+
+  it("use 'ref' identifier as first", async () => {
+    await e(
+      `
+        const Tooltip = React.forwardRef(function(inProps, ref) {
+          const handleUseRef = useForkRef(setChildNode, ref);
+          const handleFocusRef = useForkRef(focusVisibleRef, handleUseRef);
+          const handleRef = useForkRef(children.ref, handleFocusRef);
+          console.log(handleUseRef, handleFocusRef, handleRef);
+        })
+      `,
+      `
+        const Tooltip = React.forwardRef(function(inProps, ref) {
+          console.log(ref, ref, ref)
+        })
+      `
+    );
+  });
 });


### PR DESCRIPTION
The Tooltip component uses `useForkRef`, but the `ref` identifier is not at the front, and there is a non-identifier `children.ref`, which prevents the Tooltip from being converted to a suid component.